### PR TITLE
feat: use peerid mismatch error type

### DIFF
--- a/lib/identify.go
+++ b/lib/identify.go
@@ -86,17 +86,6 @@ func extractPeerIDFromError(inputErr error) (peer.ID, error) {
 		return p, nil
 	}
 
-	tlsRe := regexp.MustCompile(`expected\s(.+?),\sgot\s(.+?)$`)
-	match = tlsRe.FindStringSubmatch(errText)
-	if len(match) == 3 {
-		remotePeerIDStr := match[2]
-		p, err := peer.Decode(remotePeerIDStr)
-		if err != nil {
-			return "", fmt.Errorf("there was a peerID mismatch but the returned peerID could not be parsed, %w", err)
-		}
-		return p, nil
-	}
-
 	return "", inputErr
 }
 


### PR DESCRIPTION
Uses the go-libp2p PR in https://github.com/libp2p/go-libp2p/pull/2451.

Currently not mergeable as:
1. It fails with QUIC connections since quic-go hides the underlying error type as described in https://github.com/libp2p/go-libp2p/pull/2451#issue-1831773396
2. The go-libp2p PR is just a PR

----

Update: These were both fixed and included in go-libp2p v0.31.0