### PR TITLE
feat: Add ping with force-relay flag

### DIFF
--- a/lib/ping.go
+++ b/lib/ping.go
@@ -1,0 +1,67 @@
+package vole
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+)
+
+func Ping(ctx context.Context, direct bool, p *peer.AddrInfo) error {
+	// Set the activation threshold to 1 so that we learn our own address with just one observation. This lets us holepunch at all.
+	if direct {
+		identify.ActivationThresh = 1
+	}
+
+	h, err := libp2p.New(libp2p.EnableHolePunching())
+	if err != nil {
+		return err
+	}
+	defer h.Close()
+	h.Connect(ctx, *p)
+
+	times := 3
+
+	if !direct {
+		ctx = network.WithUseTransient(ctx, "ping")
+	}
+
+	// Reimplementing ping because the default implementation may use a relayed connection instead of a direct one
+	in := [32]byte{}
+	out := [32]byte{}
+	s, err := h.NewStream(ctx, p.ID, "/ipfs/ping/1.0.0")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < times; i++ {
+		_, err := rand.Reader.Read(in[:])
+		if err != nil {
+			return err
+		}
+
+		start := time.Now()
+		s.Write(in[:])
+		n, err := s.Read(out[:])
+		if err != nil {
+			return err
+		}
+		if n != 32 {
+			return fmt.Errorf("expected 32 bytes, got %d", n)
+		}
+		if !bytes.Equal(in[:], out[:]) {
+			return fmt.Errorf("expected %x, got %x", in[:], out[:])
+		}
+
+		fmt.Println("Took ", time.Since(start))
+		time.Sleep(time.Second)
+	}
+
+	return nil
+}

--- a/lib/ping.go
+++ b/lib/ping.go
@@ -7,19 +7,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
 func Ping(ctx context.Context, direct bool, p *peer.AddrInfo) error {
-	// Set the activation threshold to 1 so that we learn our own address with just one observation. This lets us holepunch at all.
-	if direct {
-		identify.ActivationThresh = 1
+	if !direct {
+		// We don't want a direct connection, so set this to a high value so
+		// that we don't learn our public address
+		identify.ActivationThresh = 100
 	}
 
-	h, err := libp2p.New(libp2p.EnableHolePunching())
+	h, err := libp2pHost()
 	if err != nil {
 		return err
 	}

--- a/lib/ping_test.go
+++ b/lib/ping_test.go
@@ -21,7 +21,7 @@ func TestPing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := Ping(ctx, true, &p); err != nil {
+	if err := Ping(ctx, false, &p); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/lib/ping_test.go
+++ b/lib/ping_test.go
@@ -1,0 +1,27 @@
+package vole
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func TestPing(t *testing.T) {
+	h, err := libp2p.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	p := peer.AddrInfo{
+		ID:    h.ID(),
+		Addrs: h.Addrs(),
+	}
+
+	ctx := context.Background()
+	if err := Ping(ctx, true, &p); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -307,6 +307,31 @@ Note: may not work with some transports such as p2p-circuit (not applicable) and
 							}
 							return nil
 						},
+					}, {
+						Name:      "ping",
+						ArgsUsage: "<multiaddr>",
+						Flags: []cli.Flag{
+
+							&cli.BoolFlag{
+								Name:        "direct",
+								Usage:       `Ping the peer directly rather than through a relay.`,
+								DefaultText: "false",
+								Value:       false,
+							},
+						},
+						Usage:       "ping a peer",
+						Description: "connects to the target address and pings",
+						Action: func(c *cli.Context) error {
+							if c.NArg() != 1 {
+								return fmt.Errorf("invalid number of arguments")
+							}
+							maStr := c.Args().First()
+							ai, err := peer.AddrInfoFromString(maStr)
+							if err != nil {
+								return err
+							}
+							return vole.Ping(c.Context, c.Bool("direct"), ai)
+						},
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -313,8 +313,8 @@ Note: may not work with some transports such as p2p-circuit (not applicable) and
 						Flags: []cli.Flag{
 
 							&cli.BoolFlag{
-								Name:        "direct",
-								Usage:       `Ping the peer directly rather than through a relay.`,
+								Name:        "force-relay",
+								Usage:       `Ping the peer over a relay instead of a direct connection`,
 								DefaultText: "false",
 								Value:       false,
 							},
@@ -330,7 +330,7 @@ Note: may not work with some transports such as p2p-circuit (not applicable) and
 							if err != nil {
 								return err
 							}
-							return vole.Ping(c.Context, c.Bool("direct"), ai)
+							return vole.Ping(c.Context, c.Bool("force-relay"), ai)
 						},
 					},
 				},


### PR DESCRIPTION
A bit more verbose than I would like because go-libp2p will always allow ping to go over a relayed connection.