### PR TITLE
Fix: open stream in bitswap check to ensure holepunching succeeeds before timeout

### DIFF
--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -55,6 +55,8 @@ func (o *BsCheckOutput) MarshalJSON() ([]byte, error) {
 
 var _ json.Marshaler = (*BsCheckOutput)(nil)
 
+// Passing a libp2p host is optional. Otherwise a temporary host will be created.
+// When passing a host, it should be only connceted to the passed multiaddr
 func CheckBitswapCID(ctx context.Context, h host.Host, c cid.Cid, ma multiaddr.Multiaddr, getBlock bool) (*BsCheckOutput, error) {
 	var err error
 	if h == nil {

--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 
@@ -54,8 +55,12 @@ func (o *BsCheckOutput) MarshalJSON() ([]byte, error) {
 
 var _ json.Marshaler = (*BsCheckOutput)(nil)
 
-func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr, getBlock bool) (*BsCheckOutput, error) {
-	h, err := libp2pHost()
+func CheckBitswapCID(ctx context.Context, h host.Host, c cid.Cid, ma multiaddr.Multiaddr, getBlock bool) (*BsCheckOutput, error) {
+	var err error
+	if h == nil {
+		h, err = libp2pHost()
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -76,7 +76,7 @@ func CheckBitswapCID(ctx context.Context, h host.Host, c cid.Cid, ma multiaddr.M
 
 	tctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
-	// Create a new stream to ensure hole punching happens
+	// Create a new stream to ensure we wait for hole punching even if it takes longer than the built-in limit in the Bitswap implementation
 	_, err = h.NewStream(tctx, ai.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
 	if err != nil {
 		return nil, err

--- a/lib/bitswap.go
+++ b/lib/bitswap.go
@@ -69,6 +69,14 @@ func CheckBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr, get
 		return nil, err
 	}
 
+	tctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+	// Create a new stream to ensure hole punching happens
+	_, err = h.NewStream(tctx, ai.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
+	if err != nil {
+		return nil, err
+	}
+
 	target := ai.ID
 
 	bs := bsnet.NewFromIpfsHost(h, rhelp.Null{})

--- a/lib/bitswap_test.go
+++ b/lib/bitswap_test.go
@@ -3,8 +3,9 @@ package vole
 import (
 	"context"
 	"encoding/json"
-	rhelp "github.com/libp2p/go-libp2p-routing-helpers"
 	"testing"
+
+	rhelp "github.com/libp2p/go-libp2p-routing-helpers"
 
 	"github.com/ipfs/boxo/bitswap"
 	bsnet "github.com/ipfs/boxo/bitswap/network"
@@ -43,7 +44,7 @@ func TestBitswapCheckPresent(t *testing.T) {
 
 	_ = bitswap.New(ctx, bsnetwork, bstore)
 
-	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0], true)
+	checkOutput, err := CheckBitswapCID(ctx, nil, blk.Cid(), hostAddrs[0], true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +80,7 @@ func TestBitswapCheckNotPresent(t *testing.T) {
 
 	_ = bitswap.New(ctx, bsnetwork, bstore)
 
-	checkOutput, err := CheckBitswapCID(ctx, blk.Cid(), hostAddrs[0], true)
+	checkOutput, err := CheckBitswapCID(ctx, nil, blk.Cid(), hostAddrs[0], true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ var bitswapCheckCmd = &cli.Command{
 			return err
 		}
 
-		output, err := vole.CheckBitswapCID(c.Context, bsCid, ma, getBlock)
+		output, err := vole.CheckBitswapCID(c.Context, nil, bsCid, ma, getBlock)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What's in this PR

- **fix: open stream in bitswap check to holepunch**
- **feat: allow passing in libp2p host**: this should help consumers of vole to pass a libp2p host (that might already be connected to a peer) which should make running the bitswap checks quicker and more efficiently.
